### PR TITLE
Improve root cause reporting

### DIFF
--- a/network_tester.py
+++ b/network_tester.py
@@ -26,6 +26,15 @@ def log(message):
     log_entries.append(entry)
     print(f"\n{message}")
 
+# Expose TCP connectivity test so unit tests can mock it directly
+def tcp_test(host, port):
+    """Attempt a TCP connection to ``host:port`` with a short timeout."""
+    try:
+        with socket.create_connection((host, port), timeout=5):
+            return True
+    except Exception:
+        return False
+
 # ... [other unchanged functions remain above] ...
 
 def final_root_cause_analysis():
@@ -33,62 +42,83 @@ def final_root_cause_analysis():
     failed = [k for k, v in layer_results.items() if not v]
     passed = [k for k, v in layer_results.items() if v]
 
+    summary_msg = f"Passed: {', '.join(passed) if passed else 'None'} | Failed: {', '.join(failed) if failed else 'None'}"
+    log(f"Layer Summary: {summary_msg}")
+
     if not failed:
         print("✅ All layers passed. No root cause needed.")
         return
 
     explanation = None
     recovery = None
+    advice = None
 
     if failed == ["1 - Physical"]:
         explanation = "NIC disabled, unplugged cable, or Wi-Fi turned off."
         recovery = "Check your network adapter settings, re-enable the NIC, or plug in the Ethernet cable."
+        advice = "If the cable looks fine but the interface stays down, try another port or replace the cable."
     elif failed == ["2 - Data Link"]:
         explanation = "No response from router. Check Wi-Fi or LAN cable."
         recovery = "Reconnect to Wi-Fi or reseat the LAN cable. Restart your router if needed."
+        advice = "Verify that other devices can reach the router to rule out router failure."
     elif failed == ["3 - Network"]:
         explanation = "Router/modem can't reach the internet. Check ISP."
         recovery = "Power cycle your modem/router, or contact your internet provider."
+        advice = "Check the modem's status lights for errors indicating loss of service."
     elif failed == ["4 - Transport"]:
         explanation = "TCP blocked by firewall, proxy, or ISP."
         recovery = "Check firewall settings, disable VPN, or contact IT/admin for access."
+        advice = "Temporarily disable any firewall or VPN to see if connectivity improves."
     elif failed == ["5 - Session"]:
         explanation = "Session init failed. VPN, tunneling, or remote app rejection."
         recovery = "Check VPN connection, restart session-based applications, or reauthenticate."
+        advice = "Make sure your credentials are valid and that any VPN software is up to date."
     elif failed == ["6 - Presentation"]:
         explanation = "TLS failure. Possible SSL interception or certificate issues."
         recovery = "Try a different network, check date/time settings, or update CA certificates."
+        advice = "Inspect certificate details in your browser to look for anomalies."
     elif failed == ["7 - Application"]:
         explanation = "DNS resolution failed. Misconfigured or blocked DNS."
         recovery = "Change DNS to 8.8.8.8 or 1.1.1.1, or troubleshoot DNS settings."
+        advice = "Flush the DNS cache after changing settings to ensure fresh lookups."
     elif set(failed) >= {"1 - Physical", "2 - Data Link", "3 - Network"}:
         explanation = "Complete local connection failure. Interface disabled or cable unplugged."
         recovery = "Ensure NIC is enabled and cables are securely connected. Restart your device."
+        advice = "Test with a known good cable or network card if available."
     elif set(failed) >= {"3 - Network", "4 - Transport", "5 - Session", "6 - Presentation"} and "1 - Physical" in passed and "2 - Data Link" in passed:
         explanation = "Enterprise firewall or DPI blocking internet services after gateway."
         recovery = "Check corporate security software, proxy configs, or try a trusted network."
+        advice = "Consult your network administrator to confirm if any policies recently changed."
     elif set(failed) == {"4 - Transport", "7 - Application"}:
         explanation = "Firewall or VPN likely blocking both TCP and DNS traffic."
         recovery = "Disable or reconfigure VPN, inspect firewall/proxy rules."
+        advice = "Try connecting without the VPN or firewall to verify the restriction."
     elif set(failed) == {"6 - Presentation"} and "4 - Transport" in passed:
         explanation = "TLS blocked or inspected, but TCP is open. SSL inspection suspected."
         recovery = "Use trusted network, or contact IT to bypass SSL inspection temporarily."
+        advice = "Check if a corporate proxy is intercepting HTTPS traffic." 
     elif set(failed) == {"7 - Application"} and all(x in passed for x in ["1 - Physical", "2 - Data Link", "3 - Network", "4 - Transport", "5 - Session", "6 - Presentation"]):
         explanation = "Only DNS failing. Likely DNS misconfiguration, hijack, or captive portal."
         recovery = "Switch to public DNS or log into captive portal (if applicable)."
+        advice = "Attempt accessing a site directly via IP to confirm DNS is the only issue."
     elif set(failed) == {"5 - Session", "6 - Presentation"} and all(x in passed for x in ["1 - Physical", "2 - Data Link", "3 - Network", "4 - Transport"]):
         explanation = "Session and TLS disrupted—likely service-level or protocol-specific filtering."
         recovery = "Try alternative services or networks, or contact service provider."
+        advice = "Testing with another application can confirm if the block is app-specific."
     elif set(failed) == {"6 - Presentation", "7 - Application"} and all(x in passed for x in ["1 - Physical", "2 - Data Link", "3 - Network", "4 - Transport", "5 - Session"]):
         explanation = "TLS + DNS failing. SSL inspection and DNS filtering together suspected."
         recovery = "Try a different network or consult IT to bypass network filtering."
+        advice = "Corporate filtering may require contacting IT for an exemption." 
     else:
         explanation = "Uncommon issue pattern. Try rebooting or contacting IT/network support."
         recovery = "Restart your device and network gear, then rerun diagnostics."
+        advice = "Collect diagnostic logs to assist support staff in troubleshooting." 
 
     
     log(f"Root Cause Inference: {explanation}")
     log(f"Recovery Suggestion: {recovery}")
+    if advice:
+        log(f"Actionable Advice: {advice}")
 
 
 def run_diagnostics():
@@ -121,13 +151,6 @@ def run_diagnostics():
         log(f"[Layer 3 - Network] Pinging 8.8.8.8: {'Success' if success else 'Fail'}")
 
         # Layer 4 - Transport
-        def tcp_test(host, port):
-            try:
-                with socket.create_connection((host, port), timeout=5):
-                    return True
-            except:
-                return False
-
         s443 = tcp_test("example.com", 443)
         s80 = tcp_test("example.com", 80)
         layer_results["4 - Transport"] = s443 or s80


### PR DESCRIPTION
## Summary
- expose `tcp_test` at module level so unit tests can import it
- print a summary of OSI layers that passed/failed
- give actionable advice for each failure pattern in `final_root_cause_analysis`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f74e4d188322a487670c810b69be